### PR TITLE
add missing import in com.ibm.ws.diagnostics

### DIFF
--- a/dev/com.ibm.ws.diagnostics/src/com/ibm/ws/diagnostics/osgi/RegionIntrospectionComponentManager.java
+++ b/dev/com.ibm.ws.diagnostics/src/com/ibm/ws/diagnostics/osgi/RegionIntrospectionComponentManager.java
@@ -4,6 +4,7 @@ package com.ibm.ws.diagnostics.osgi;
 import org.apache.felix.scr.component.manager.ComponentManager;
 import org.apache.felix.scr.component.manager.Parameters;
 import org.apache.felix.scr.component.manager.ReturnValue;
+import org.eclipse.equinox.region.RegionDigraph;
 import org.osgi.service.component.ComponentContext;
 
 /**


### PR DESCRIPTION
compile error due to omitted import